### PR TITLE
Add secrets inheritance to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,3 +17,4 @@ jobs:
       github-repository-name: ${{ github.repository }}
       github-repository-branch: ${{ vars.SECURITY_SCAN_GIT_BRANCH }}
       github-sha: ${{ github.sha }}
+    secrets: inherit


### PR DESCRIPTION
## Description

This PR adds the `secrets: inherit` configuration in the security workflow. This is needed so the reusable workflow can access the `DEFECTDOJO_API_KEY` organizational secret on the calling repository.

The logic is the following:
- _Current Action_ repo (i.e. Sinan-BE) reads organizational secret
- _Current Action_ Allows inheritance (in another words sends) secret to reused workflow (devops-github-actions)
- **devops-github-actions** is not being run, but just its code being executed by _Current Action_.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Other (Please specify):

## How it is tested?

Tested on other repositories to confirm `secrets: inherit` is needed.

## Checklist

- [ ] I have added necessary tests.
- [ ] All new and existing tests pass.
- [ ] I have updated the documentation as needed.